### PR TITLE
FA5 compatibility fixes

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,4 +1,6 @@
 <script type="text/discourse-plugin" version="0.4">
+const { iconNode } = require("discourse-common/lib/icon-library");
+
 api.decorateWidget("header-icons:before", helper => {
   var hlt = settings.Header_links;
   return hlt.split("|").map(i => {
@@ -12,7 +14,7 @@ api.decorateWidget("header-icons:before", helper => {
           title: seg[0],
           target: "_" + seg[4]
         },
-        helper.h("i.fa.fa-" + seg[1] + ".d-icon.d-icon-" + seg[1])
+        iconNode(seg[1])
       )
     ]);
   });

--- a/settings.yml
+++ b/settings.yml
@@ -3,3 +3,9 @@ Header_links:
   default: 'Dektop-mobile link,facebook,https://facebook.com,vdm,blank|Mobile-only link,twitter,https://twitter.com,vdo,blank'
   description:
     en: "Comma delimited in this order: Title,Icon,URL,View,Target. View can be:  visible on both desktop and mobile devices (vdm), Desktop only (vdo) or mobile only (vmo). Target can be: same tab (self) or new tab (blank)."
+Svg_icons: 
+  type: 'list'
+  list_type: 'compact'
+  default: 'fa-facebook|fa-twitter'
+  description: 
+    en: "Include FontAwesome 5 icon classes for each icon used in the list."


### PR DESCRIPTION
- Adds a new field to list svg icons that FA5 SVG Sprite subset (currently in branch fontawesome5) can pick up 
- Uses iconNode for icon markup
- is still compatible with current Discourse `master` (FA4.7 via icon fonts)